### PR TITLE
6. Update the code to reflect the name change `subject_hcp.txt` --> `session_hcp.txt

### DIFF
--- a/templates/diffusion/clean_data.jinja2
+++ b/templates/diffusion/clean_data.jinja2
@@ -5,7 +5,7 @@ mv $COMMON/sessions/$SUBJ/hcp/$SUBJ/* $COMMON
 mv $COMMON/sessions/specs $COMMON/ProcessingInfo
 mv $COMMON/processing $COMMON/ProcessingInfo
 mv $COMMON/info/hcpls $COMMON/ProcessingInfo
-cp $COMMON/sessions/$SUBJ/subject_hcp.txt $COMMON/ProcessingInfo/processing
+cp $COMMON/sessions/$SUBJ/session_hcp.txt $COMMON/ProcessingInfo/processing
 cp $COMMON/sessions/$SUBJ/hcpls/hcpls2nii.log $COMMON/ProcessingInfo/processing
 find $COMMON \
     -not -path "$COMMON/T1w/*" \

--- a/templates/functional/clean_data.jinja2
+++ b/templates/functional/clean_data.jinja2
@@ -7,7 +7,7 @@ mv $COMMON/sessions/$SUBJ/hcp/$SUBJ/* $COMMON
 mv $COMMON/processing $COMMON/ProcessingInfo
 mv $COMMON/sessions/specs $COMMON/ProcessingInfo
 mv $COMMON/info/hcpls $COMMON/ProcessingInfo
-mv $COMMON/sessions/$SUBJ/subject_hcp.txt $COMMON/ProcessingInfo/processing
+mv $COMMON/sessions/$SUBJ/session_hcp.txt $COMMON/ProcessingInfo/processing
 mv $COMMON/sessions/$SUBJ/hcpls/hcpls2nii.log $COMMON/ProcessingInfo/processing
 find $COMMON -maxdepth 1 -mindepth 1 \
     \( -type d -not -path "$COMMON/T1w" \

--- a/templates/generic/clean_data.jinja2
+++ b/templates/generic/clean_data.jinja2
@@ -11,7 +11,7 @@ mv $COMMON/$SUBJ/T*w $COMMON
 mv $COMMON/sessions/specs $COMMON/ProcessingInfo
 mv $COMMON/processing $COMMON/ProcessingInfo
 mv $COMMON/info/hcpls $COMMON/ProcessingInfo
-mv $COMMON/sessions/$SUBJ/subject_hcp.txt $COMMON/ProcessingInfo/processing
+mv $COMMON/sessions/$SUBJ/session_hcp.txt $COMMON/ProcessingInfo/processing
 mv $COMMON/sessions/$SUBJ/hcpls/hcpls2nii.log $COMMON/ProcessingInfo/processing
 find $COMMON \
     -not -path "$COMMON/T*w/*" \

--- a/templates/structuralhe/clean_data.jinja2
+++ b/templates/structuralhe/clean_data.jinja2
@@ -5,7 +5,7 @@ mv $COMMON/$SUBJ/T*w $COMMON
 mv $COMMON/sessions/specs $COMMON/ProcessingInfo
 mv $COMMON/processing $COMMON/ProcessingInfo
 mv $COMMON/info/hcpls $COMMON/ProcessingInfo
-mv $COMMON/sessions/$SUBJ/subject_hcp.txt $COMMON/ProcessingInfo/processing
+mv $COMMON/sessions/$SUBJ/session_hcp.txt $COMMON/ProcessingInfo/processing
 mv $COMMON/sessions/$SUBJ/hcpls/hcpls2nii.log $COMMON/ProcessingInfo/processing
 find $COMMON \
     -not -path "$COMMON/T*w/*" \


### PR DESCRIPTION
Per Harms:
> 6. It looks to me like the subject_hcp.txt file that we were copying previously to "ProcessingInfo/processing" has probably changed its name to session_hcp.txt within QuNex. So, need to update the code to reflect the name change.